### PR TITLE
Lua 5.3 updates

### DIFF
--- a/alt_getopt
+++ b/alt_getopt
@@ -25,9 +25,12 @@ for i,v in ipairs (opts) do
 end
 
 optarg,optind = alt_getopt.get_opts (arg, "hVvo:n:S:", long_opts)
+local fin_options = {}
 for k,v in pairs (optarg) do
-   io.write ("fin-option `" .. k .. "': " .. v .. "\n")
+   table.insert (fin_options, "fin-option `" .. k .. "': " .. v .. "\n")
 end
+table.sort (fin_options)
+io.write (table.concat (fin_options))
 
 for i = optind,#arg do
    io.write (string.format ("ARGV [%s] = %s\n", i, arg [i]))

--- a/alt_getopt
+++ b/alt_getopt
@@ -12,7 +12,7 @@ local long_opts = {
    ["set-output"] = "o"
 }
 
-local ret
+local opts
 local optarg
 local optind
 opts,optind,optarg = alt_getopt.get_ordered_opts (arg, "hVvo:n:S:", long_opts)

--- a/alt_getopt
+++ b/alt_getopt
@@ -1,6 +1,6 @@
 #!/usr/bin/env lua
 
-require "alt_getopt"
+local alt_getopt = require "alt_getopt"
 
 local long_opts = {
    verbose = "v",

--- a/alt_getopt.lua
+++ b/alt_getopt.lua
@@ -24,8 +24,6 @@ local type, pairs, ipairs, io, os = type, pairs, ipairs, io, os
 alt_getopt = {}
 
 local function convert_short2long (opts)
-   local i = 1
-   local len = #opts
    local ret = {}
 
    for short_opt, accept_arg in opts:gmatch("(%w)(:?)") do
@@ -116,7 +114,7 @@ function alt_getopt.get_ordered_opts (arg, sh_opts, long_opts)
 	 count = count + 1
 
       elseif a:sub (1, 1) == "-" then
-	 local j
+
 	 for j=2,a:len () do
 	    local opt = canonize (options, a:sub (j, j))
 

--- a/alt_getopt.lua
+++ b/alt_getopt.lua
@@ -40,7 +40,7 @@ end
 
 local function err_unknown_opt (opt)
    exit_with_error ("Unknown option `-" ..
-		    (#opt > 1 and "-" or "") .. opt .. "'\n", 1)
+                   (#opt > 1 and "-" or "") .. opt .. "'\n", 1)
 end
 
 local function canonize (options, opt)
@@ -52,7 +52,7 @@ local function canonize (options, opt)
       opt = options [opt]
 
       if not options [opt] then
-	 err_unknown_opt (opt)
+         err_unknown_opt (opt)
       end
    end
 
@@ -74,72 +74,72 @@ function alt_getopt.get_ordered_opts (arg, sh_opts, long_opts)
       local a = arg [i]
 
       if a == "--" then
-	 i = i + 1
-	 break
+         i = i + 1
+         break
 
       elseif a == "-" then
-	 break
+         break
 
       elseif a:sub (1, 2) == "--" then
-	 local pos = a:find ("=", 1, true)
+         local pos = a:find ("=", 1, true)
 
-	 if pos then
-	    local opt = a:sub (3, pos-1)
+      if pos then
+         local opt = a:sub (3, pos-1)
 
-	    opt = canonize (options, opt)
+         opt = canonize (options, opt)
 
-	    if options [opt] == 0 then
-	       exit_with_error ("Bad usage of option `" .. a .. "'\n", 1)
-	    end
+         if options [opt] == 0 then
+            exit_with_error ("Bad usage of option `" .. a .. "'\n", 1)
+         end
 
-	    optarg [count] = a:sub (pos+1)
-	    opts [count] = opt
-	 else
-	    local opt = a:sub (3)
+         optarg [count] = a:sub (pos+1)
+         opts [count] = opt
+      else
+         local opt = a:sub (3)
 
-	    opt = canonize (options, opt)
+         opt = canonize (options, opt)
 
-	    if options [opt] == 0 then
-	       opts [count] = opt
-	    else
-	       if i == #arg then
-		  exit_with_error ("Missed value for option `" .. a .. "'\n", 1)
-	       end
+         if options [opt] == 0 then
+            opts [count] = opt
+         else
+            if i == #arg then
+               exit_with_error ("Missed value for option `" .. a .. "'\n", 1)
+            end
 
-	       optarg [count] = arg [i+1]
-	       opts [count] = opt
-	       i = i + 1
-	    end
-	 end
-	 count = count + 1
+            optarg [count] = arg [i+1]
+            opts [count] = opt
+            i = i + 1
+         end
+      end
+      count = count + 1
 
       elseif a:sub (1, 1) == "-" then
 
-	 for j=2,a:len () do
-	    local opt = canonize (options, a:sub (j, j))
+         for j=2,a:len () do
+            local opt = canonize (options, a:sub (j, j))
 
-	    if options [opt] == 0 then
-	       opts [count] = opt
-	       count = count + 1
-	    elseif a:len () == j then
-	       if i == #arg then
-		  exit_with_error ("Missed value for option `-" .. opt .. "'\n", 1)
-	       end
+            if options [opt] == 0 then
+               opts [count] = opt
+               count = count + 1
+            elseif a:len () == j then
+               if i == #arg then
+                  exit_with_error ("Missed value for option `-" .. opt .. "'\n", 1)
+               end
 
-	       optarg [count] = arg [i+1]
-	       opts [count] = opt
-	       i = i + 1
-	       count = count + 1
-	       break
-	    else
-	       optarg [count] = a:sub (j+1)
-	       opts [count] = opt
-	       count = count + 1
-	       break
-	    end
-	 end
+               optarg [count] = arg [i+1]
+               opts [count] = opt
+               i = i + 1
+               count = count + 1
+               break
+            else
+               optarg [count] = a:sub (j+1)
+               opts [count] = opt
+               count = count + 1
+               break
+            end
+         end
       else
-	 break
+         break
       end
 
       i = i + 1
@@ -154,9 +154,9 @@ function alt_getopt.get_opts (arg, sh_opts, long_opts)
    local opts,optind,optarg = alt_getopt.get_ordered_opts (arg, sh_opts, long_opts)
    for i,v in ipairs (opts) do
       if optarg [i] then
-	 ret [v] = optarg [i]
+         ret [v] = optarg [i]
       else
-	 ret [v] = 1
+         ret [v] = 1
       end
    end
 

--- a/alt_getopt.lua
+++ b/alt_getopt.lua
@@ -21,7 +21,7 @@
 
 local type, pairs, ipairs, io, os = type, pairs, ipairs, io, os
 
-module ("alt_getopt")
+alt_getopt = {}
 
 local function convert_short2long (opts)
    local i = 1
@@ -61,7 +61,7 @@ local function canonize (options, opt)
    return opt
 end
 
-function get_ordered_opts (arg, sh_opts, long_opts)
+function alt_getopt.get_ordered_opts (arg, sh_opts, long_opts)
    local i      = 1
    local count  = 1
    local opts   = {}
@@ -150,10 +150,10 @@ function get_ordered_opts (arg, sh_opts, long_opts)
    return opts,i,optarg
 end
 
-function get_opts (arg, sh_opts, long_opts)
+function alt_getopt.get_opts (arg, sh_opts, long_opts)
    local ret = {}
 
-   local opts,optind,optarg = get_ordered_opts (arg, sh_opts, long_opts)
+   local opts,optind,optarg = alt_getopt.get_ordered_opts (arg, sh_opts, long_opts)
    for i,v in ipairs (opts) do
       if optarg [i] then
 	 ret [v] = optarg [i]
@@ -164,3 +164,5 @@ function get_opts (arg, sh_opts, long_opts)
 
    return ret,optind
 end
+
+return alt_getopt

--- a/tests/test.out
+++ b/tests/test.out
@@ -28,19 +28,19 @@ option `n': 999
 option `n': 9999
 option `len': 5
 option `fake'
-fin-option `len': 5
 fin-option `fake': 1
-fin-option `o': 234
+fin-option `len': 5
 fin-option `n': 9999
+fin-option `o': 234
 ARGV [11] = /dev/null
 =================================================================
 ======= args: ../alt_getopt -hVv -- -1 -2 -3
 option `h'
 option `V'
 option `v'
+fin-option `V': 1
 fin-option `h': 1
 fin-option `v': 1
-fin-option `V': 1
 ARGV [3] = -1
 ARGV [4] = -2
 ARGV [5] = -3
@@ -77,21 +77,21 @@ Unknown option `-1'
 option `h'
 option `v'
 option `V'
-fin-option `h': 1
 fin-option `V': 1
+fin-option `h': 1
 fin-option `v': 1
 =================================================================
 ======= args: ../alt_getopt -ho 123
 option `h'
 option `o': 123
-fin-option `o': 123
 fin-option `h': 1
+fin-option `o': 123
 =================================================================
 ======= args: ../alt_getopt -hoV 123
 option `h'
 option `o': V
-fin-option `o': V
 fin-option `h': 1
+fin-option `o': V
 ARGV [2] = 123
 =================================================================
 ======= args: ../alt_getopt --unknown
@@ -102,8 +102,8 @@ option `o': file.out
 option `n': NNN
 option `len': LENGTH
 fin-option `len': LENGTH
-fin-option `o': file.out
 fin-option `n': NNN
+fin-option `o': file.out
 =================================================================
 ======= args: ../alt_getopt --output --file--
 option `o': --file--
@@ -126,5 +126,5 @@ option `o': file1
 option `S': 111
 option `o': file2
 option `o': file3
-fin-option `o': file3
 fin-option `S': 111
+fin-option `o': file3


### PR DESCRIPTION
Hello! This PR makes changes necessary for lua-alt-getopt to work with the latest Lua version (5.3).
- In Lua 5.2 `module` was deprecated, in Lua 5.3 it is not present by default. I changed module definition to follow modern style; however, `alt_getopt` global is still set for compatibility.
- Tests used to rely on iteration order of `pairs`, which can easily change if the order of insertion of keys changes, or another Lua version is used. In Lua 5.3 iteration order is completely unreliable as hashing function is seeded with a random number on start-up IIRC. I changed tests to sort pairs before outputting them.
- Tiny fixes (unused variables, mixed spaces and tabs).
